### PR TITLE
Avoid boilerplate switch

### DIFF
--- a/lib/mimi/logger.rb
+++ b/lib/mimi/logger.rb
@@ -139,24 +139,12 @@ module Mimi
     #
     # @param value [String,Symbol,Integer]
     #
-    def self.level_from_any(value)
+ j   def self.level_from_any(value)
       return value if value.is_a?(Integer)
-      case value.to_s.downcase.to_sym
-      when :debug
-        ::Logger::DEBUG
-      when :info
-        ::Logger::INFO
-      when :warn
-        ::Logger::WARN
-      when :error
-        ::Logger::ERROR
-      when :fatal
-        ::Logger::FATAL
-      when :unknown
-        ::Logger::UNKNOWN
-      else
-        raise ArgumentError, "Invalid value for the log level: '#{value}'"
-      end
+
+      ::Logger.const_get(value.to_s.upcase.to_sym)
+    rescue NameError
+      raise ArgumentError, "Invalid value for the log level: '#{value}'"
     end
 
     # Returns formatter Proc object depending on configured format

--- a/lib/mimi/logger.rb
+++ b/lib/mimi/logger.rb
@@ -139,7 +139,7 @@ module Mimi
     #
     # @param value [String,Symbol,Integer]
     #
-   def self.level_from_any(value)
+    def self.level_from_any(value)
       return value if value.is_a?(Integer)
 
       ::Logger.const_get(value.to_s.upcase.to_sym)

--- a/lib/mimi/logger.rb
+++ b/lib/mimi/logger.rb
@@ -139,7 +139,7 @@ module Mimi
     #
     # @param value [String,Symbol,Integer]
     #
- j   def self.level_from_any(value)
+   def self.level_from_any(value)
       return value if value.is_a?(Integer)
 
       ::Logger.const_get(value.to_s.upcase.to_sym)

--- a/spec/mimi/logger_spec.rb
+++ b/spec/mimi/logger_spec.rb
@@ -63,4 +63,38 @@ describe Mimi::Logger do
       expect(subject.context_id).to eq sample_context_id
     end
   end # with logging context support
+
+  describe '.level_from_any' do
+    it 'can be called with a number' do
+      expect(described_class.level_from_any(1)).to eq(1)
+    end
+
+    it 'can be called with :debug' do
+      expect(described_class.level_from_any('debug')).to eq(::Logger::DEBUG)
+    end
+
+    it 'can be called with info' do
+      expect(described_class.level_from_any('info')).to eq(::Logger::INFO)
+    end
+
+    it 'can be called with warn' do
+      expect(described_class.level_from_any('warn')).to eq(::Logger::WARN)
+    end
+
+    it 'can be called with error' do
+      expect(described_class.level_from_any('error')).to eq(::Logger::ERROR)
+    end
+
+    it 'can be called with error' do
+      expect(described_class.level_from_any('fatal')).to eq(::Logger::FATAL)
+    end
+
+    it 'can be called with unknown' do
+      expect(described_class.level_from_any('unknown')).to eq(::Logger::UNKNOWN)
+    end
+
+    it 'cannot be called with random' do
+      expect { described_class.level_from_any('random') }.to raise_error(ArgumentError)
+    end
+  end
 end


### PR DESCRIPTION
While reading the code I just noticed this switch could be avoided by using 'const_get' since the names used are identical. With that the switch clause can be avoided completely.